### PR TITLE
Add LiveSplit duty-objective splitting and a single-duty mode

### DIFF
--- a/XIVSplits/Config/Config.cs
+++ b/XIVSplits/Config/Config.cs
@@ -17,6 +17,7 @@ namespace XIVSplits.Config
 
         public bool AutoStartTimer { get; set; } = true;
         public bool AutoCompletionTimeSplit { get; set; } = true;
+        public bool SingleDutyMode { get; set; } = false;
 
         public Dictionary<string, List<Objective>> DutyObjectives { get; set; } = new();
         public List<Objective> GenericObjectives { get; set; } = new();

--- a/XIVSplits/ObjectiveManager.cs
+++ b/XIVSplits/ObjectiveManager.cs
@@ -192,6 +192,7 @@ namespace XIVSplits
                         // trigger split
                         PluginLog.Information($"Splitting on duty objective: {objective}");
                         InternalTimer.ManualSplit(objective);
+                        LiveSplit.Send("split");
                     }
                 }
 
@@ -210,6 +211,7 @@ namespace XIVSplits
                         // trigger split
                         PluginLog.Information($"Splitting on objective: {objective}");
                         InternalTimer.ManualSplit(objective);
+                        LiveSplit.Send("split");
                     }
                 }
             }

--- a/XIVSplits/ObjectiveManager.cs
+++ b/XIVSplits/ObjectiveManager.cs
@@ -67,12 +67,18 @@ namespace XIVSplits
                 return null;
             }
 
-            AtkUnitBase* addon = (AtkUnitBase*)GameGui.GetAddonByName("_ToDoList", 1).Address;
+            var addonPtr = GameGui.GetAddonByName("_ToDoList", 1);
+            if (addonPtr == null || addonPtr.Address == nint.Zero)
+            {
+                return null;
+            }
+
+            AtkUnitBase* addon = (AtkUnitBase*)addonPtr.Address;
             if (addon == null)
             {
                 return null;
             }
-            
+
             List<(string objective, float progress)> objectives = new();
 
             AtkUldManager manager = addon->UldManager;
@@ -80,8 +86,13 @@ namespace XIVSplits
             {
                 AtkResNode* node = manager.NodeList[i];
 
+                if (node == null || node->Type != NodeType.Component)
+                {
+                    continue;
+                }
+
                 AtkComponentNode* componentNode = (AtkComponentNode*)node;
-                if (componentNode == null || componentNode->Component == null)
+                if (componentNode->Component == null)
                 {
                     continue;
                 }
@@ -92,14 +103,25 @@ namespace XIVSplits
                 for (int j = 0; j < nodeManager.NodeListCount; j++)
                 {
                     AtkResNode* lineNode = nodeManager.NodeList[j];
-                    if (lineNode->NodeId == 6)
+                    if (lineNode == null)
+                    {
+                        continue;
+                    }
+
+                    if (lineNode->Type == NodeType.Text && lineNode->NodeId == 6)
                     {
                         // Objective text
                         AtkTextNode* lineTextNode = (AtkTextNode*)lineNode;
-                        objective = lineTextNode->NodeText.ToString();
+
+                        var utf8 = lineTextNode->NodeText;
+                        if (utf8.StringPtr != null && utf8.Length > 0)
+                        {
+                            objective = utf8.ToString();
+                        }
+                        
                     }
 
-                    if (lineNode->NodeId == 2)
+                    if (lineNode->Type == NodeType.NineGrid && lineNode->NodeId == 2)
                     {
                         // Objective progress bar
                         AtkNineGridNode* lineProgressNode = (AtkNineGridNode*)lineNode;
@@ -122,7 +144,6 @@ namespace XIVSplits
 
             return objectives;
         }
-
 
         private unsafe string? GetDutyName()
         {

--- a/XIVSplits/ObjectiveManager.cs
+++ b/XIVSplits/ObjectiveManager.cs
@@ -144,6 +144,7 @@ namespace XIVSplits
 
         private void HandleDutyObjectives()
         {
+            var config = ConfigService.Get();
             string? dutyName = GetDutyName();
             if (dutyName == null || string.IsNullOrWhiteSpace(dutyName))
             {
@@ -151,6 +152,11 @@ namespace XIVSplits
                 {
                     // reset objectives
                     PluginLog.Information($"Duty ended: {CurrentDuty}");
+                    if (config.SingleDutyMode)
+                    {
+                        InternalTimer.Stop();
+                        LiveSplit.Send("reset");
+                    }
                     AcknowledgedObjectives.Clear();
                     CurrentDuty = "";
                 }
@@ -158,7 +164,6 @@ namespace XIVSplits
                 return;
             }
 
-            var config = ConfigService.Get();
             if (CurrentDuty != dutyName)
             {
                 // reset objectives

--- a/XIVSplits/UI/ObjectivesConfig.cs
+++ b/XIVSplits/UI/ObjectivesConfig.cs
@@ -194,6 +194,21 @@ namespace XIVSplits.UI
             {
                 ImGui.SetTooltip($"Will split the timer when \"{ObjectiveManager.CompletionTimeRegex()}\" is sent to chat.");
             }
+
+            ImGui.SameLine();
+            bool singleDuty = config.SingleDutyMode;
+            if (ImGui.Checkbox("Single Duty Mode", ref singleDuty) && singleDuty != config.SingleDutyMode)
+            {
+                config.SingleDutyMode = singleDuty;
+                ConfigService.Save();
+            }
+            ImGui.SameLine();
+            // hover text for regex help
+            ImGui.TextDisabled("(?)");
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.SetTooltip("Resets the internal timer and livesplit if connected on duty end, do not use this if doing a longer run.");
+            }
         }
 
 


### PR DESCRIPTION
Adds LiveSplit split triggers for duty objective completion.
When duty objectives are detected, XIVSplits will now notify LiveSplit to issue a split.

This PR also introduces a Single Duty Mode, with a new option in the Duty Objectives config tab.
When enabled (disabled by default), this mode resets both the internal timer and LiveSplit when the duty end is detected.