### PR TITLE
LiveSplit duty-objective splitting + single-duty mode

### DIFF
--- a/XIVSplits/Config/Config.cs
+++ b/XIVSplits/Config/Config.cs
@@ -17,6 +17,7 @@ namespace XIVSplits.Config
 
         public bool AutoStartTimer { get; set; } = true;
         public bool AutoCompletionTimeSplit { get; set; } = true;
+        public bool SingleDutyMode { get; set; } = false;
 
         public Dictionary<string, List<Objective>> DutyObjectives { get; set; } = new();
         public List<Objective> GenericObjectives { get; set; } = new();

--- a/XIVSplits/UI/ObjectivesConfig.cs
+++ b/XIVSplits/UI/ObjectivesConfig.cs
@@ -194,6 +194,21 @@ namespace XIVSplits.UI
             {
                 ImGui.SetTooltip($"Will split the timer when \"{ObjectiveManager.CompletionTimeRegex()}\" is sent to chat.");
             }
+
+            ImGui.SameLine();
+            bool singleDuty = config.SingleDutyMode;
+            if (ImGui.Checkbox("Single Duty Mode", ref singleDuty) && singleDuty != config.SingleDutyMode)
+            {
+                config.SingleDutyMode = singleDuty;
+                ConfigService.Save();
+            }
+            ImGui.SameLine();
+            // hover text for regex help
+            ImGui.TextDisabled("(?)");
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.SetTooltip("Resets the internal timer and livesplit if connected on duty end, do not use this if doing a longer run.");
+            }
         }
 
 


### PR DESCRIPTION
- Added LiveSplit duty-objective splitting.
- Implemented singleDutyMode, which when enabled in ObjectivesConfig (off by default) resets the internal timer and LiveSplit on duty-end detection.
- Added type checking to prevent crashes caused by invalid memory access that started appearing after these additions back in 7.3 also seems to fix the issues that started appearing in 7.4 See #8.
- updated for 7.4 dalamud api 14